### PR TITLE
Fix: restore loading of fonts in dist-demo, drop unplugin-fonts

### DIFF
--- a/packages/ui-solid/package.json
+++ b/packages/ui-solid/package.json
@@ -61,7 +61,6 @@
     "@vitest/ui": "^2.0.5",
     "babel-plugin-transform-jsbi-to-bigint": "^1.4.0",
     "jsdom": "^25.0.0",
-    "unplugin-fonts": "^1.1.1",
     "vite": "^5.4.3",
     "vite-plugin-babel": "^1.2.0",
     "vite-plugin-dts": "^4.1.0",

--- a/packages/ui-solid/vite.config.ts
+++ b/packages/ui-solid/vite.config.ts
@@ -6,7 +6,6 @@
 import type { CollectionValues } from '@getodk/common/types/collections/CollectionValues.ts';
 import suidPlugin from '@suid/vite-plugin';
 import { resolve as resolvePath } from 'node:path';
-import unpluginFonts from 'unplugin-fonts/vite';
 import dts from 'vite-plugin-dts';
 import solidPlugin from 'vite-plugin-solid';
 import { defineConfig } from 'vitest/config';
@@ -87,24 +86,6 @@ export default defineConfig(({ mode }) => {
 			force: true,
 		},
 		plugins: [
-			unpluginFonts({
-				fontsource: {
-					families: [
-						{
-							/**
-							 * Name of the font family.
-							 * Require the `@fontsource/roboto` package to be installed.
-							 */
-							name: 'Roboto',
-							/**
-							 * Load only a subset of the font family.
-							 */
-							weights: [400, 500, 700],
-						},
-					],
-				},
-			}),
-
 			// SUID = Solid MUI component library
 			suidPlugin(),
 

--- a/packages/web-forms/package.json
+++ b/packages/web-forms/package.json
@@ -64,7 +64,6 @@
     "primevue-sass-theme": "https://github.com/primefaces/primevue-sass-theme.git#3.52.0",
     "ramda": "^0.30.1",
     "sass": "^1.77.2",
-    "unplugin-fonts": "^1.1.1",
     "vite": "^5.4.3",
     "vite-plugin-css-injected-by-js": "^3.5.1",
     "vite-plugin-static-copy": "^1.0.6",

--- a/packages/web-forms/src/demo/demo.ts
+++ b/packages/web-forms/src/demo/demo.ts
@@ -4,7 +4,10 @@ import { createApp } from 'vue';
 import { webFormsPlugin } from '../WebFormsPlugin';
 import OdkWebFormDemo from './OdkWebFormDemo.vue';
 
-import 'unfonts.css';
+import hankenGrotesk400 from '@fontsource/hanken-grotesk/400.css?inline';
+import hankenGrotesk600 from '@fontsource/hanken-grotesk/600.css?inline';
+import hankenGrotesk700 from '@fontsource/hanken-grotesk/700.css?inline';
+import roboto from '@fontsource/roboto/300.css?inline';
 import icomoon from '../assets/css/icomoon.css?inline';
 import theme from '../themes/2024-light/theme.scss?inline';
 // TODO/sk: Purge it - postcss-purgecss
@@ -13,7 +16,16 @@ import primeflex from 'primeflex/primeflex.css?inline';
 import demoStyles from '../assets/css/style.scss?inline';
 import router from './router';
 
-const styles = [icomoon, theme, primeflex, demoStyles].join('\n\n');
+const styles = [
+	roboto,
+	icomoon,
+	hankenGrotesk400,
+	hankenGrotesk600,
+	hankenGrotesk700,
+	theme,
+	primeflex,
+	demoStyles,
+].join('\n\n');
 const stylesheet = new CSSStyleSheet();
 
 stylesheet.replaceSync(styles);

--- a/packages/web-forms/src/index.ts
+++ b/packages/web-forms/src/index.ts
@@ -1,7 +1,7 @@
 import { webFormsPlugin } from './WebFormsPlugin';
 import OdkWebForm from './components/OdkWebForm.vue';
 
-import 'unfonts.css';
+import '@fontsource/roboto/300.css';
 import './assets/css/icomoon.css';
 import './themes/2024-light/theme.scss';
 

--- a/packages/web-forms/vite.config.ts
+++ b/packages/web-forms/vite.config.ts
@@ -5,8 +5,6 @@ import { execSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { fileURLToPath, URL } from 'node:url';
-import { FontsourceFontFamily } from 'unplugin-fonts/types';
-import unpluginFonts from 'unplugin-fonts/vite';
 import type { LibraryOptions, PluginOption } from 'vite';
 import cssInjectedByJsPlugin from 'vite-plugin-css-injected-by-js';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
@@ -75,26 +73,17 @@ export default defineConfig(({ mode }) => {
 	let external: string[];
 	let globals: Record<string, string>;
 	const extraPlugins: PluginOption[] = [];
-	const extraFonts: FontsourceFontFamily[] = [];
 
 	if (isVueBundled) {
 		external = [];
 		globals = {};
 		extraPlugins.push(copyConfigFile);
-		extraFonts.push({
-			name: 'Hanken Grotesk',
-			weights: [400, 600, 700],
-		});
 	} else {
 		external = ['vue'];
 		globals = { vue: 'Vue' };
 
 		if (isDev) {
 			extraPlugins.push(copyConfigFile);
-			extraFonts.push({
-				name: 'Hanken Grotesk',
-				weights: [400, 600, 700],
-			});
 		}
 
 		lib = {
@@ -110,30 +99,7 @@ export default defineConfig(({ mode }) => {
 			__WEB_FORMS_VERSION__: `"v${currentVersion}"`,
 		},
 		base: './',
-		plugins: [
-			vue(),
-			vueJsx(),
-			cssInjectedByJsPlugin(),
-			unpluginFonts({
-				fontsource: {
-					families: [
-						{
-							/**
-							 * Name of the font family.
-							 * Require the `@fontsource/roboto` package to be installed.
-							 */
-							name: 'Roboto',
-							/**
-							 * Load only a subset of the font family.
-							 */
-							weights: [300],
-						},
-						...extraFonts,
-					],
-				},
-			}),
-			...extraPlugins,
-		],
+		plugins: [vue(), vueJsx(), cssInjectedByJsPlugin(), ...extraPlugins],
 		resolve: {
 			alias: {
 				'@getodk/common': resolve(__dirname, '../common/src'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -2430,11 +2430,6 @@ acorn-jsx@^5.3.2:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
-acorn@^8.10.0, acorn@^8.9.0:
-  version "8.10.0"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
-  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
-
 acorn@^8.11.3:
   version "8.11.3"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.11.3.tgz#71e0b14e13a4ec160724b38fb7b0f233b1b81d7a"
@@ -2444,6 +2439,11 @@ acorn@^8.12.0:
   version "8.12.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.12.1.tgz#71616bdccbe25e27a54439e0046e89ca76df2248"
   integrity sha512-tcpGyI9zbizT9JbV6oYE477V6mTlXvvi0T0G3SNIYE2apm/G5huBa1+K89VGeovbg+jycCrfhl3ADxErOuO6Jg==
+
+acorn@^8.9.0:
+  version "8.10.0"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.10.0.tgz#8be5b3907a67221a81ab23c7889c4c5526b62ec5"
+  integrity sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==
 
 agent-base@^7.0.2, agent-base@^7.1.0, agent-base@^7.1.1:
   version "7.1.1"
@@ -3579,7 +3579,7 @@ fast-diff@^1.1.2:
   resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.3.0.tgz#ece407fa550a64d638536cd727e129c61616e0f0"
   integrity sha512-VxPP4NqbUjj6MaAOafWeUn2cXWLcCtljklUtZf0Ind4XQ+QPtmA0b18zZy0jIQx+ExRVCR/ZQpBmik5lXshNsw==
 
-fast-glob@^3.2.11, fast-glob@^3.2.12, fast-glob@^3.2.9, fast-glob@^3.3.0:
+fast-glob@^3.2.11, fast-glob@^3.2.9, fast-glob@^3.3.0:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/fast-glob/-/fast-glob-3.3.1.tgz#784b4e897340f3dbbef17413b3f11acf03c874c4"
   integrity sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg==
@@ -6186,24 +6186,6 @@ universalify@^2.0.0:
   resolved "https://registry.yarnpkg.com/universalify/-/universalify-2.0.1.tgz#168efc2180964e6386d061e094df61afe239b18d"
   integrity sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==
 
-unplugin-fonts@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/unplugin-fonts/-/unplugin-fonts-1.1.1.tgz#cd6600d2a048d8237a010b53c9c4dfb1ea73d80f"
-  integrity sha512-/Aw/rL9D2aslGGM0vi+2R2aG508RSwawLnnBuo+JDSqYc4cHJO1R1phllhN6GysEhBp/6a4B6+vSFPVapWyAAw==
-  dependencies:
-    fast-glob "^3.2.12"
-    unplugin "^1.3.1"
-
-unplugin@^1.3.1:
-  version "1.5.0"
-  resolved "https://registry.yarnpkg.com/unplugin/-/unplugin-1.5.0.tgz#8938ae84defe62afc7757df9ca05d27160f6c20c"
-  integrity sha512-9ZdRwbh/4gcm1JTOkp9lAkIDrtOyOxgHmY7cjuwI8L/2RTikMcVG25GsZwNAgRuap3iDw2jeq7eoqtAsz5rW3A==
-  dependencies:
-    acorn "^8.10.0"
-    chokidar "^3.5.3"
-    webpack-sources "^3.2.3"
-    webpack-virtual-modules "^0.5.0"
-
 untildify@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/untildify/-/untildify-4.0.0.tgz#2bc947b953652487e4600949fb091e3ae8cd919b"
@@ -6464,16 +6446,6 @@ webidl-conversions@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-7.0.0.tgz#256b4e1882be7debbf01d05f0aa2039778ea080a"
   integrity sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==
-
-webpack-sources@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-3.2.3.tgz#2d4daab8451fd4b240cc27055ff6a0c2ccea0cde"
-  integrity sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==
-
-webpack-virtual-modules@^0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz#362f14738a56dae107937ab98ea7062e8bdd3b6c"
-  integrity sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==
 
 whatwg-encoding@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
It turns out that the build product of unplugin-fonts and `import ‘unfonts.css’` is broken. Specifically:

1. The fonts are bundled in `$buildDir/assets/$foo.woff`
2. The fonts are referenced in the built CSS as `./foo.woff` (note: not in the assets directory)

The paths are relative to the wrong relative source: they are referenced from CSS inlined in JS in `$buildDir/assets`, but loaded relative to `$buildDir/index.html`. This results in **no fonts being loaded at all**. They’ll 404 in a static file server, or load index.html as a fallback for some SPA-oriented servers like `vite serve`.

This reverts the change in b3ae435 to use unplugin-fonts for font loading. And having now confirmed that we are not getting anything out of unplugin-fonts from that prior approach, it also removes the unplugin-fonts Vite plugin entirely.